### PR TITLE
US006: feat(feed): launch initial version of home page feed

### DIFF
--- a/ms-tweet-service/src/main/java/com/ms/tweet/client/UserClient.java
+++ b/ms-tweet-service/src/main/java/com/ms/tweet/client/UserClient.java
@@ -56,6 +56,10 @@ public interface UserClient {
     @GetMapping(USER_ID_USERNAME)
     Long getUserIdByUsername(@PathVariable("username") String username);
 
+    @CircuitBreaker(name = USER_SERVICE, fallbackMethod = "defaultEmptyIdsList")
+    @PostMapping(VALID_IDS)
+    List<Long> getValidUserIds(@RequestBody IdsRequest request);
+
     default Long defaultEmptyPinnedTweetId(Throwable throwable) {
         return 0L;
     }

--- a/ms-tweet-service/src/main/java/com/ms/tweet/controller/rest/TweetController.java
+++ b/ms-tweet-service/src/main/java/com/ms/tweet/controller/rest/TweetController.java
@@ -17,8 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.http.WebSocket;
 import java.util.List;
 
-import static com.gmail.merikbest2015.constants.PathConstants.IMAGES_USER_ID;
-import static com.gmail.merikbest2015.constants.PathConstants.UI_V1_TWEETS;
+import static com.gmail.merikbest2015.constants.PathConstants.*;
 import static com.gmail.merikbest2015.constants.WebsocketConstants.TOPIC_FEED_ADD;
 import static com.gmail.merikbest2015.constants.WebsocketConstants.TOPIC_USER_ADD_TWEET;
 
@@ -28,7 +27,7 @@ import static com.gmail.merikbest2015.constants.WebsocketConstants.TOPIC_USER_AD
 public class TweetController {
     private final TweetService tweetService;
     private final WebSocketClient webSocketClient;
-    @GetMapping("/user/{userId}")
+    @GetMapping(USER_USER_ID)
     public ResponseEntity<List<TweetUserResponse>> getUserTweets(
             @PathVariable("userId") Long userId,
             @PageableDefault(size = 10) Pageable pageable) {
@@ -39,6 +38,12 @@ public class TweetController {
     @GetMapping(IMAGES_USER_ID)
     public ResponseEntity<List<ProfileTweetImageResponse>> getUserTweetImages(@PathVariable("userId") Long userId) {
         return ResponseEntity.ok(tweetService.getUserTweetImages(userId));
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<TweetResponse>> getTweets(@PageableDefault Pageable pageable) {
+        HeaderResponse<TweetResponse> response = tweetService.getTweets(pageable);
+        return ResponseEntity.ok().headers(response.getHeaders()).body(response.getItems());
     }
 
     @PostMapping

--- a/ms-tweet-service/src/main/java/com/ms/tweet/helper/TweetValidationHelper.java
+++ b/ms-tweet-service/src/main/java/com/ms/tweet/helper/TweetValidationHelper.java
@@ -1,11 +1,16 @@
 package com.ms.tweet.helper;
 
+import com.gmail.merikbest2015.dto.request.IdsRequest;
 import com.gmail.merikbest2015.exception.ApiRequestException;
 import com.gmail.merikbest2015.util.AuthUtil;
 import com.ms.tweet.client.UserClient;
+import com.ms.tweet.repository.TweetRepository;
+import jakarta.persistence.Id;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.gmail.merikbest2015.constants.ErrorMessage.*;
 
@@ -13,7 +18,11 @@ import static com.gmail.merikbest2015.constants.ErrorMessage.*;
 @RequiredArgsConstructor
 public class TweetValidationHelper {
     private final UserClient userClient;
-
+    private final TweetRepository tweetRepository;
+    public List<Long> getValidUserIds() {
+        List<Long> tweetAuthorIds = tweetRepository.getTweetAuthorIds();
+        return userClient.getValidUserIds(new IdsRequest(tweetAuthorIds));
+    }
     public void validateUserProfile(Long userId) {
         if (!userClient.isUserExists(userId)) {
             throw new ApiRequestException(String.format(USER_ID_NOT_FOUND, userId), HttpStatus.NOT_FOUND);

--- a/ms-tweet-service/src/main/java/com/ms/tweet/repository/TweetRepository.java
+++ b/ms-tweet-service/src/main/java/com/ms/tweet/repository/TweetRepository.java
@@ -2,7 +2,9 @@ package com.ms.tweet.repository;
 
 import com.ms.tweet.model.Tweet;
 import com.ms.tweet.repository.projection.ProfileTweetImageProjection;
+import com.ms.tweet.repository.projection.TweetProjection;
 import com.ms.tweet.repository.projection.TweetUserProjection;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -14,6 +16,21 @@ import java.util.Optional;
 
 @Repository
 public interface TweetRepository extends JpaRepository<Tweet, Long> {
+
+    // TODO: check blocked user if existed in userIds list
+    @Query("SELECT tweet FROM Tweet tweet " +
+            "WHERE tweet.authorId IN :userIds " +
+            "AND tweet.addressedUsername IS NULL " +
+            "AND tweet.scheduledDate IS NULL " +
+            "AND tweet.deleted = false " +
+            "ORDER BY tweet.dateTime DESC")
+    Page<TweetProjection> getTweetsByAuthorsIds(@Param("userIds") List<Long> userIds, Pageable pageable);
+
+    @Query("SELECT DISTINCT tweet.authorId FROM Tweet tweet " +
+            "WHERE tweet.addressedUsername IS NULL " +
+            "AND tweet.scheduledDate IS NULL " +
+            "AND tweet.deleted = false")
+    List<Long> getTweetAuthorIds();
 
     @Query("SELECT tweet FROM Tweet tweet WHERE tweet.id = :tweetId")
     <T> Optional<T> getTweetById(@Param("tweetId") Long tweetId, Class<T> type);

--- a/ms-tweet-service/src/main/java/com/ms/tweet/service/TweetService.java
+++ b/ms-tweet-service/src/main/java/com/ms/tweet/service/TweetService.java
@@ -1,6 +1,7 @@
 package com.ms.tweet.service;
 
 import com.gmail.merikbest2015.dto.HeaderResponse;
+import com.gmail.merikbest2015.dto.request.IdsRequest;
 import com.gmail.merikbest2015.dto.response.tweet.TweetResponse;
 import com.gmail.merikbest2015.mapper.BasicMapper;
 import com.gmail.merikbest2015.util.AuthUtil;
@@ -15,6 +16,7 @@ import com.ms.tweet.repository.RetweetRepository;
 import com.ms.tweet.repository.TweetRepository;
 import com.ms.tweet.repository.projection.ProfileTweetImageProjection;
 import com.ms.tweet.repository.projection.RetweetProjection;
+import com.ms.tweet.repository.projection.TweetProjection;
 import com.ms.tweet.repository.projection.TweetUserProjection;
 import lombok.RequiredArgsConstructor;
 import org.mapstruct.Mapper;
@@ -55,6 +57,13 @@ public class TweetService {
         }
         Page<TweetUserProjection> tweetsPageable = tweetServiceHelper.getPageableTweetProjectionList(pageable, userTweets, tweets.size() + retweets.size());
         return basicMapper.getHeaderResponse(tweetsPageable, TweetUserResponse.class);
+    }
+
+    @Transactional
+    public HeaderResponse<TweetResponse> getTweets(Pageable pageable) {
+        List<Long> validUserIds = tweetValidationHelper.getValidUserIds();
+        Page<TweetProjection> tweetProjectionPage = tweetRepository.getTweetsByAuthorsIds(validUserIds, pageable);
+        return basicMapper.getHeaderResponse(tweetProjectionPage, TweetResponse.class);
     }
 
     public List<ProfileTweetImageResponse> getUserTweetImages(Long userId) {

--- a/ms-user-service/src/main/java/com/twitter/ms/controller/api/UserApiController.java
+++ b/ms-user-service/src/main/java/com/twitter/ms/controller/api/UserApiController.java
@@ -1,5 +1,6 @@
 package com.twitter.ms.controller.api;
 
+import com.gmail.merikbest2015.dto.request.IdsRequest;
 import com.gmail.merikbest2015.dto.response.tweet.TweetAuthorResponse;
 import com.twitter.ms.service.UserApiService;
 import com.twitter.ms.service.UserService;
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.gmail.merikbest2015.constants.PathConstants.*;
 
@@ -56,5 +59,10 @@ public class UserApiController {
     @GetMapping(TWEET_AUTHOR_USER_ID)
     public TweetAuthorResponse getTweetAuthor(@PathVariable("userId") Long userId) {
         return userService.getTweetAuthor(userId);
+    }
+
+    @PostMapping(VALID_IDS)
+    public List<Long> getValidUserIds(@RequestBody IdsRequest request) {
+        return userService.getValidUserIds(request);
     }
 }

--- a/ms-user-service/src/main/java/com/twitter/ms/repository/UserRepository.java
+++ b/ms-user-service/src/main/java/com/twitter/ms/repository/UserRepository.java
@@ -91,4 +91,17 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User user SET user.profileStarted = true WHERE user.id = :userId")
     void updateProfileStarted(@Param("userId") Long userId);
+
+    @Query("SELECT user FROM User user " +
+            "LEFT JOIN user.userBlockedList userBlockedList " +
+            "WHERE userBlockedList.id = :authUserId AND user.id IN :userIds")
+    List<Long> getUserIdsWhoBlockedMyProfile(@Param("userIds") List<Long> userIds, @Param("authUserId") Long authUserId);
+
+    @Query("SELECT user.id FROM User user " +
+            "LEFT JOIN user.following following " +
+            "WHERE user.id IN :userIds " +
+            "AND (user.privateProfile = false " +
+            "   OR (user.privateProfile = true AND (following.id = :authUserId OR user.id = :authUserId)) " +
+            "   AND user.active = true)")
+    List<Long> getValidUserIdsByIds(@Param("userIds") List<Long> userIds, @Param("authUserId") Long authUserId);
 }

--- a/ms-user-service/src/main/java/com/twitter/ms/service/UserApiService.java
+++ b/ms-user-service/src/main/java/com/twitter/ms/service/UserApiService.java
@@ -1,5 +1,6 @@
 package com.twitter.ms.service;
 
+import com.gmail.merikbest2015.dto.request.IdsRequest;
 import com.gmail.merikbest2015.dto.response.tweet.TweetAuthorResponse;
 import com.gmail.merikbest2015.mapper.BasicMapper;
 import com.gmail.merikbest2015.util.AuthUtil;
@@ -11,6 +12,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -53,6 +56,13 @@ public class UserApiService {
     public void updateTweetCount(boolean increase) {
         Long authUserId = AuthUtil.getAuthenticatedUserId();
         userRepository.updateTweetCount(increase, authUserId);
+    }
+
+    public List<Long> getValidUserIds(IdsRequest request) {
+        Long authUserId = AuthUtil.getAuthenticatedUserId();
+        List<Long> blockedUserIds = userRepository.getUserIdsWhoBlockedMyProfile(request.getIds(), authUserId);
+        request.getIds().removeAll(blockedUserIds);
+        return userRepository.getValidUserIdsByIds(request.getIds(), authUserId);
     }
 
     public TweetAuthorResponse getTweetAuthor(Long userId) {


### PR DESCRIPTION
Introduce the first iteration of the home page feed feature, displaying curated content to users. Includes basic backend setup and UI integration.

- Add endpoints in tweet and user service for homepage.
- Add initial feed display on the home page.

This initial launch sets the groundwork for future enhancements and personalization of the user feed.